### PR TITLE
Add PclZip utility to whitelist

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -274,3 +274,4 @@ fc8f1e9f0ff666af7beb3f61b055c0e8  /core/model/smarty/sysplugins/smarty_internal_
 3c9137d88a00b1ae0b41ff6a70571615  /assets/components/tinymcewrapper/frontend/imogen_theme/js/jquery.js
 bb127b5ce56b45e8b4b91de2e60dd9eb  /assets/components/googleanalytics/js/mgr/libs/highcharts.js
 7d7958bb0a9438a8966807f9202d0bce  /assets/components/tinymce/jscripts/tiny_mce/plugins/spellchecker/classes/PSpellShell.php
+3ee0a4d8a06cedc0a56f29e8f351ef72  /pclzip-2-8-2/pclzip.lib.php


### PR DESCRIPTION
PclZip library offers compression and extraction functions for Zip formatted archives (WinZip, PKZIP).

Source file downloads here: http://www.phpconcept.net/pclzip/pclzip-downloads