### PR TITLE
Use array() instead of the short array syntax []

### DIFF
--- a/scan.php
+++ b/scan.php
@@ -511,7 +511,7 @@ class MalwareScanner
         }
 
         if ($this->outputFormat) {
-            $map = [
+            $map = array(
                 '%S' => $state,
                 '%T' => $ctime,
                 '%M' => $hash,
@@ -519,9 +519,9 @@ class MalwareScanner
                 '%P' => $pattern,
                 '%C' => $comment,
                 '%L' => $lineNumber,
-            ];
+            );
         } else {
-            $map = [
+            $map = array(
                 '%S' => $state_color . '# ' . $state . $this->ANSI_OFF,
                 '%T' => $this->ANSI_BLUE . $ctime . $this->ANSI_OFF,
                 '%M' => $this->ANSI_BLUE . $hash . $this->ANSI_OFF,
@@ -529,7 +529,7 @@ class MalwareScanner
                 '%P' => $state_color . '#' . $pattern . $this->ANSI_OFF,
                 '%C' => $this->ANSI_BLUE . $comment . $this->ANSI_OFF,
                 '%L' => $lineNumber,
-            ];
+            );
         }
 
         if ($this->outputFormat) {
@@ -769,7 +769,7 @@ class MalwareScanner
         }
 
         $content = gzdecode(file_get_contents($file));
-        $this->combined_whitelist = [];
+        $this->combined_whitelist = array();
         $this->combined_whitelist_count = 0;
         foreach (explode("\n", $content) as $line) { // faster than strtok, but needs more memory
             if ($line) {


### PR DESCRIPTION
Short array syntax [] was added in PHP 5.4 but the scanner should be able to work with [PHP >=5.2.0](https://github.com/scr34m/php-malware-scanner/blob/master/composer.json#L9).