### PR TITLE
Cast $needle in calls to strpos/stripos to string to avoid automatic …

### DIFF
--- a/scan.php
+++ b/scan.php
@@ -709,14 +709,14 @@ class MalwareScanner
     //Returns true if the raw string exists in the file contents.
     private function scanFunc_STR(&$pattern, &$content)
     {
-        return strpos($content, $pattern);
+        return strpos($content, (string)$pattern);
     }
 
     //Performs raw string, case insensitive matching.
     //Returns true if the raw string exists in the file contents, ignoring case.
     private function scanFunc_STRI(&$pattern, &$content)
     {
-        return stripos($content, $pattern);
+        return stripos($content, (string)$pattern);
     }
 
     //Performs regular expression matching.


### PR DESCRIPTION
…ordinal conversion of integer patterns

After commit 29e6c73558ac986f47246d9ad082cc75b61f94e5, I started getting alerts on all my PHP files for pattern 6368646972. The problem is that the file() function used to loop over the contents of the pattern files returns all-numeric lines as integers, and that strpos/stripos on older PHP deals with integer $needle arguments oddly:

"Prior to PHP 8.0.0, if needle is not a string, it is converted to an integer and applied as the ordinal value of a character." (https://www.php.net/manual/en/function.strpos.php)

So 6368646972 is getting converted to <, which appears as character 0 in most PHP files.

It seems like the easiest fix for this is to cast $needle as a string in the calls to strpos/stripos in scanFunc_STR and scanFunc_STRI, which this pull request does. You can't cast it at the call to $this->$scanFunction because of call by reference. You could also fix it by making sure all patterns get read as strings from the pattern files.